### PR TITLE
feat(makefile): add Makefile

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,46 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ."
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor
+/out
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+BINARY_NAME=forum_api
+
+build: # Build binary
+	mkdir -p ./out/bin
+	GO111MODULE=on go build -mod vendor -o ./out/bin/$(BINARY_NAME) .
+
+run: build # Build and run binary
+	./out/bin/${BINARY_NAME}
+
+watch: # Hot reload on change
+	${GOPATH}/air -c .air.toml
+
+clean: # Remove build and temporary files
+	go clean
+	rm -rf ./out ./tmp
+
+vendor: # Copy all dependencies to /vendor
+	go mod vendor
+
+test: # Run all test suites
+	go test -v ./...
+
+test_coverage: # Run tests coverage
+	mkdir -p ./out
+	go test -cover -covermode=count -coverprofile=./out/coverage.out ./...
+	go tool cover -func ./out/coverage.out 
+	go tool cover -html=./out/coverage.out -o ./out/coverage.html
+	
+# Saving this for when CI is implemented in this project
+# lint: # Lint project # https://golangci-lint.run/usage/install/
+# 	golang-ci-lint run --enable-all
+


### PR DESCRIPTION
Closes #2 
Adding Makefile to automate the following commands:

- Build the project.
- Run the project.
- Run the server on hot-reload mode.
- Clean any files created during the build and test process, and also cached files.
- Automatically run test.
- Create coverage reports.
- Copy dependencies for local use.

Also add a `.gitignore` file to avoid commiting any file created as part of the build and test processes.