### PR TITLE
Feature/implement router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 BINARY_NAME=forum_api
 
+install: # Install third party packages
+	@go get ./...
+	
 build: # Build binary
 	@mkdir -p ./out/bin
 	@GO111MODULE=on go build -mod vendor -o ./out/bin/$(BINARY_NAME) .

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/yasledesma/forum-api
 
 go 1.20
+
+require github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/handlers.go
+++ b/handlers.go
@@ -5,217 +5,203 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/julienschmidt/httprouter"
 )
 
-func handlePosts(w http.ResponseWriter, r *http.Request) {
-	var post Post
-	var posts []Post
-	var comments []Comment
+func GetPosts(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string][]Post{"posts": db.Posts})
+}
 
-	switch r.Method {
-	case http.MethodGet:
-		if r.URL.Path == "" {
-			w.Header().Add("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string][]Post{"posts": db.Posts})
-			return
-		}
+func AddPost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var p Post
 
-		if strings.Contains(r.URL.Path, "comments") {
-			id, err := strconv.Atoi(r.URL.Path[:strings.Index(r.URL.Path, "/")])
+	if !strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		http.Error(w, "'Content-Type' header is not 'application/json'", http.StatusUnsupportedMediaType)
+		return
+	}
 
-			if err != nil {
-				w.Header().Add("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				json.NewEncoder(w).Encode(map[string]string{"error": "comments not found"})
-				return
-			}
+	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
 
-			for i := range db.Comments {
-				if db.Comments[i].PostId == id {
-					comments = append(comments, db.Comments[i])
-				}
-			}
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&p)
 
-			if comments != nil {
-				w.Header().Add("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(map[string][]Comment{"comments": comments})
-				return
-			}
+	if err != nil {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "couldn't add post"})
+		return
+	}
 
-			w.Header().Add("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			json.NewEncoder(w).Encode(map[string]string{"error": "comments not found"})
-			return
-		}
+	// TODO: this is business logic. move it to a service.
+	p.Id = db.Posts[len(db.Posts)-1].Id + 1 // save as next index
+	p.Upvotes = 1
+	db.Posts = append(db.Posts, p)
 
-		id, err := strconv.Atoi(r.URL.Path)
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(p)
+}
 
-		if err != nil {
-			w.Header().Add("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			json.NewEncoder(w).Encode(map[string]string{"error": "post not found"})
-			return
-		}
+func GetPost(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	id, err := strconv.Atoi(params.ByName("pid"))
 
-		for i := range db.Posts {
-			if db.Posts[i].Id == id {
-				w.Header().Add("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(db.Posts[i])
-				return
-			}
-		}
-
+	if err != nil {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode(map[string]string{"error": "post not found"})
-	case http.MethodDelete:
-		var comments []Comment
+		return
+	}
 
-		id, err := strconv.Atoi(r.URL.Path)
-
-		if err != nil {
-			w.Header().Add("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			json.NewEncoder(w).Encode(map[string]string{"error": "post not found"})
-			return
-		}
-
-		for i := range db.Posts {
-			if db.Posts[i].Id != id {
-				posts = append(posts, db.Posts[i])
-			} else {
-				post = db.Posts[i]
-			}
-		}
-
-		for i := range db.Comments {
-			if db.Comments[i].PostId != id {
-				comments = append(comments, db.Comments[i])
-			}
-		}
-
-		if post.Id != 0 {
-			db.Posts = posts
-			db.Comments = comments
+	for i := range db.Posts {
+		if db.Posts[i].Id == id {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(post)
+			json.NewEncoder(w).Encode(db.Posts[i])
 			return
 		}
+	}
 
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotFound)
+	json.NewEncoder(w).Encode(map[string]string{"error": "post not found"})
+}
+
+func DeletePost(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	var post Post
+	var posts []Post
+
+	id, err := strconv.Atoi(params.ByName("pid"))
+
+	if err != nil {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "can't delete post"})
-	case http.MethodPost:
-		var p Post
-		var c Comment
-
-		if !strings.Contains(r.Header.Get("Content-Type"), "application/json") {
-			http.Error(w, "'Content-Type' header is not 'application/json'", http.StatusUnsupportedMediaType)
-			return
-		}
-
-		if strings.Contains(r.URL.Path, "comments/") {
-			id, err := strconv.Atoi(r.URL.Path[strings.LastIndexAny(r.URL.Path, "/")+1:])
-
-			if err != nil {
-				w.Header().Add("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				json.NewEncoder(w).Encode(map[string]string{"error": "comment not found"})
-				return
-			}
-
-			r.Body = http.MaxBytesReader(w, r.Body, 1048576)
-
-			for i := range db.Comments {
-				if db.Comments[i].Id == id {
-					c = db.Comments[i]
-				}
-			}
-
-			dec := json.NewDecoder(r.Body)
-			dec.DisallowUnknownFields()
-			err = dec.Decode(&c)
-
-			if err != nil || c.Id < 1 {
-				w.Header().Add("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				json.NewEncoder(w).Encode(map[string]string{"error": "couldn't edit comment"})
-				return
-			}
-
-			db.Comments[id-1] = c
-			w.Header().Add("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(c)
-			return
-		}
-
-		if strings.Contains(r.URL.Path, "/comments") {
-			id, err := strconv.Atoi(r.URL.Path[:strings.Index(r.URL.Path, "/")])
-
-			if err != nil {
-				w.Header().Add("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				json.NewEncoder(w).Encode(map[string]string{"error": "post not found"})
-				return
-			}
-
-			r.Body = http.MaxBytesReader(w, r.Body, 1048576)
-
-			dec := json.NewDecoder(r.Body)
-			dec.DisallowUnknownFields()
-			err = dec.Decode(&c)
-
-			if err != nil {
-				w.Header().Add("Content-Type", "application/json")
-				w.WriteHeader(http.StatusBadRequest)
-				json.NewEncoder(w).Encode(map[string]string{"error": "couldn't add post"})
-				return
-			}
-
-			var index int = 1
-
-			if len(db.Comments) != 0 {
-				index = len(db.Comments) - 1
-			}
-
-			c.Id = db.Comments[index].Id + 1
-			c.PostId = id
-			c.Upvotes = 1
-			db.Comments = append(db.Comments, c)
-
-			w.Header().Add("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(c)
-			return
-		}
-
-		r.Body = http.MaxBytesReader(w, r.Body, 1048576)
-
-		dec := json.NewDecoder(r.Body)
-		dec.DisallowUnknownFields()
-		err := dec.Decode(&p)
-
-		if err != nil {
-			w.Header().Add("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": "couldn't add post"})
-			return
-		}
-
-		p.Id = db.Posts[len(db.Posts)-1].Id + 1
-		p.Upvotes = 1
-		db.Posts = append(db.Posts, p)
-
-		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(p)
-	default:
-		w.Header().Set("Allow", "GET, POST, DELETE")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(map[string]string{"error": "post not found"})
+		return
 	}
+
+	for i := range db.Posts {
+		if db.Posts[i].Id != id {
+			posts = append(posts, db.Posts[i])
+		} else {
+			post = db.Posts[i]
+		}
+	}
+
+	if post.Id != 0 {
+		db.Posts = posts
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(post)
+		return
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotFound)
+	json.NewEncoder(w).Encode(map[string]string{"error": "can't delete post"})
+}
+
+func GetComments(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	var comments []Comment
+
+	id, err := strconv.Atoi(params.ByName("pid"))
+
+	if err != nil {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "comments not found"})
+		return
+	}
+
+	for i := range db.Comments {
+		if db.Comments[i].PostId == id {
+			comments = append(comments, db.Comments[i])
+		}
+	}
+
+	if comments != nil {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string][]Comment{"comments": comments})
+		return
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotFound)
+	json.NewEncoder(w).Encode(map[string]string{"error": "comments not found"})
+}
+
+func AddComment(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+    var c Comment
+
+    id, err := strconv.Atoi(params.ByName("pid"))
+
+    if err != nil {
+        w.Header().Add("Content-Type", "application/json")
+        w.WriteHeader(http.StatusNotFound)
+        json.NewEncoder(w).Encode(map[string]string{"error": "post not found"})
+        return
+    }
+
+    r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+
+    dec := json.NewDecoder(r.Body)
+    dec.DisallowUnknownFields()
+    err = dec.Decode(&c)
+
+    var index int = 1
+
+    if len(db.Comments) != 0 {
+        index = len(db.Comments) - 1
+    }
+
+    c.Id = db.Comments[index].Id + 1
+    c.PostId = id
+    c.Upvotes = 1
+    db.Comments = append(db.Comments, c)
+
+    w.Header().Add("Content-Type", "application/json")
+    w.WriteHeader(http.StatusCreated)
+    json.NewEncoder(w).Encode(c)
+}
+
+
+func UpdateComment(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+    var c Comment
+
+    id, err := strconv.Atoi(params.ByName("cid"))
+    
+    if err != nil {
+        w.Header().Add("Content-Type", "application/json")
+        w.WriteHeader(http.StatusNotFound)
+        json.NewEncoder(w).Encode(map[string]string{"error": "comment not found"})
+        return
+    }
+
+    r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+
+    for i := range db.Comments {
+        if db.Comments[i].Id == id {
+            c = db.Comments[i]
+        }
+    }
+
+    dec := json.NewDecoder(r.Body)
+    dec.DisallowUnknownFields()
+    err = dec.Decode(&c)
+
+    if err != nil || c.Id < 1 {
+        w.Header().Add("Content-Type", "application/json")
+        w.WriteHeader(http.StatusBadRequest)
+        json.NewEncoder(w).Encode(map[string]string{"error": "couldn't edit comment"})
+        return
+    }
+
+    db.Comments[id-1] = c
+    w.Header().Add("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    json.NewEncoder(w).Encode(c)
 }

--- a/main.go
+++ b/main.go
@@ -4,15 +4,20 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+    "github.com/julienschmidt/httprouter"
 )
 
 func main() {
-	router := http.NewServeMux()
+	router := httprouter.New()
 
-	router.Handle(
-        "/api/posts/",
-		http.StripPrefix("/api/posts/", http.HandlerFunc(handlePosts)),
-	)
+    router.GET("/api/posts/", GetPosts)
+    router.POST("/api/posts/", AddPost)
+    router.GET("/api/posts/:pid/", GetPost)
+    router.DELETE("/api/posts/:pid/", DeletePost)
+    router.POST("/api/posts/:pid/comments/", AddComment)
+    router.GET("/api/posts/:pid/comments/", GetComments)
+    router.POST("/api/posts/:pid/comments/:cid", UpdateComment)
 
 	fmt.Println("Server running on http://localhost:8080...")
 	log.Fatal(http.ListenAndServe(":8080", router))


### PR DESCRIPTION
Closes #5 

The original routing implementation was made to explore Go's standard router and its capabilities.
Now I decided to implement a more popular and reliable router like 'httprouter' for a few reasons:
1.  To simplify route handling in the API.
2. Because I don't plan to work on a custom router yet.
3. Because I intent to grow this toy project beyond its [API Specifications](https://backend-course.cornellappdev.com/chapters/routes/api), so I need reliable tools to  avoid mental overhead.
4. So I can concentrate on learning new things.
