### PR TITLE
ci(workflow): add deploy and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,8 @@ name: Deploy new version on Render
 
 on: 
   push:
-    branches: 
-      - 'main'
     tags:
-      - 'v[\d]+\.[\d]+\.[\d]+*'
+      - 'v*.*.*'
       
 jobs:
   ci:
@@ -14,6 +12,10 @@ jobs:
       matrix:
         go-version: [ '1.21.x' ]
     steps:
+      - name: Exit if not on master branch
+        if: endsWith(github.ref, 'master') == false
+        run: exit -1
+          
       - name: Install dependencies
         run: |
           go mod download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: Deploy new version on Render
+
+on: 
+  push:
+    branches: 
+      - 'main'
+    tags:
+      - 'v[\d]+\.[\d]+\.[\d]+*'
+      
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.21.x' ]
+    steps:
+      - name: Install dependencies
+        run: |
+          go mod download
+          go mod verify
+          
+      - name: Run and upload test results
+        env:
+          TAG: ${GITHUB_REF#refs/*/}
+        run: |
+          mkdir -p ./out
+          go test -cover -covermode=count -coverprofile=./out/coverage-$TAG.out ./...
+          go tool cover -func ./out/coverage-$TAG.out
+          go tool cover -html=./out/coverage-$TAG.out -o ./out/coverage-$TAG.html
+        uses: actions/upload-artifact@v4
+        with:
+          name: results
+          path: ./out/*
+        continue-on-error: false
+        if-no-files-found: error
+
+      - name: Deploy
+        run: |
+          curl secrets.RENDER_DEPLOY_HOOK_URL
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${TAG#v}" \
+              --generate-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
         run: |
           go mod download
           go mod verify
-          
-      - name: Run and upload test results
+
+      - name: Run test coverage
         env:
           TAG: ${GITHUB_REF#refs/*/}
         run: |
@@ -27,11 +27,13 @@ jobs:
           go test -cover -covermode=count -coverprofile=./out/coverage-$TAG.out ./...
           go tool cover -func ./out/coverage-$TAG.out
           go tool cover -html=./out/coverage-$TAG.out -o ./out/coverage-$TAG.html
+        continue-on-error: false
+          
+      - name: Upload test results
         uses: actions/upload-artifact@v4
         with:
           name: results
           path: ./out/*
-        continue-on-error: false
         if-no-files-found: error
 
       - name: Deploy
@@ -47,3 +49,4 @@ jobs:
               --repo="$GITHUB_REPOSITORY" \
               --title="${TAG#v}" \
               --generate-notes
+              


### PR DESCRIPTION
Adding workflow definition for:
1. Generate test coverage report.
2. Deploy to Render.
3. Generate a release + notes.

This is triggered on each tag push to the main branch.