### PR TITLE
ci(workflow): add deployment and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         go-version: [ '1.21.x' ]
     steps:
+      - uses: actions/checkout@v2
       # TODO: add this step back later
       # - name: Exit if not on main branch
       #   env:
@@ -27,7 +28,7 @@ jobs:
 
       - name: Run test coverage
         env:
-          TAG: ${GITHUB_REF#refs/*/}
+          TAG: ${{ github.ref_name }}
         run: |
           mkdir -p ./out
           go test -cover -covermode=count -coverprofile=./out/coverage-$TAG.out ./...
@@ -42,8 +43,10 @@ jobs:
           path: ./out/*
 
       - name: Deploy
+        env:
+          deploy_url: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
         run: |
-          curl secrets.RENDER_DEPLOY_HOOK_URL
+          curl "$deploy_url"
 
       - name: Create release
         env:


### PR DESCRIPTION

Adding workflow definition for:

1. Generate test coverage report.
2. Deploy to Render.
3. Generate a release + notes.

This is triggered on each tag push to the main branch.