### PR TITLE
ci(workflow): add deployment and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: Deploy new version on Render
+
+on: 
+  push:
+    tags:
+      - 'v*.*.*'
+      
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.21.x' ]
+    steps:
+      - uses: actions/checkout@v2
+      # TODO: add this step back later
+      # - name: Exit if not on main branch
+      #   env:
+      #     BRANCH: ${GITHUB_WORKFLOW_REF#refs/*/}
+      #   run: echo $BRANCH
+      #   if: ${{ $BRANCH == 'main' }}
+      #   run: exit -1
+          
+      - name: Install dependencies
+        run: |
+          go mod download
+          go mod verify
+
+      - name: Run test coverage
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          mkdir -p ./out
+          go test -cover -covermode=count -coverprofile=./out/coverage-$TAG.out ./...
+          go tool cover -func ./out/coverage-$TAG.out
+          go tool cover -html=./out/coverage-$TAG.out -o ./out/coverage-$TAG.html
+        continue-on-error: false
+          
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: results
+          path: ./out/*
+
+      - name: Deploy
+        env:
+          deploy_url: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          curl "$deploy_url"
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${TAG#v}" \
+              --generate-notes
+              

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For building and/or running a binary outside the container, you can use `make bu
 
 Commands that are not part of the Makefile can be run by spinning up a terminal inside the container with `make term`.
 
+## Usage
 ### Testing
 All test suites can be run at the same time with:
 
@@ -36,4 +37,13 @@ Also, if you want to run an specifict test suite or test, you can spin-up a term
 ```
 go test -v -run <test_suite>/<test>
 ```
+
+### Deployment
+To trigger the deployment pipeline, you need to create and push a new tag with the format:
+
+```
+v*.*.*
+```
+
+This will call the Render hook and create a new release with auto-generated notes.
 


### PR DESCRIPTION
Closes #14 
Adding workflow definition for:

1. Generate test coverage report.
2. Deploy to Render.
3. Generate a release + notes.

This is triggered on each tag push to the main branch.

Also adding the necessary documentation that indicates how to trigger a deployment.

A rollback job will be added in the future.
